### PR TITLE
fix install deps webpack image and lbpng on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Calma! Antes de começar a codar, precisamos intalar as dependências do projeto
 npm install
 ```
 
+Tem um macOS ae? ops, poderá ocorrer um problema com a libpng, faça o seguinte, vamos remover o image-webpack-loader e file-loader, instalar o libpng via homebrew e reinstalar as dependencias.
+
+```bash
+npm uninstall -D file-loader image-webpack-loader
+brew install libpng
+npm install -D file-loader image-webpack-loader
+```
+
 Bora codar? Inicie seu ambiente executando o comando abaixo, assim que executar o comando, será aberto seu browser favorito. Este será seu ambiente de desenvolvimento e teste.
 
 ```bash


### PR DESCRIPTION
macos presents problems when installing the file loader and image manipulation plugins when libpng is not installed on the system, so I just made a comment in the readme for macos users to be able to upload the system without surprises